### PR TITLE
Jbtm 3843

### DIFF
--- a/ArjunaJTS/integration/src/test/java/com/arjuna/ats/jta/distributed/SimpleIsolatedServers.java
+++ b/ArjunaJTS/integration/src/test/java/com/arjuna/ats/jta/distributed/SimpleIsolatedServers.java
@@ -17,6 +17,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
+import jakarta.transaction.HeuristicMixedException;
 import jakarta.transaction.NotSupportedException;
 import jakarta.transaction.RollbackException;
 import jakarta.transaction.Status;
@@ -103,6 +104,45 @@ public class SimpleIsolatedServers {
         }
         completionCounter.reset();
         lookupProvider.clear();
+    }
+
+    @Test
+    public void testRestoreStateAfterXA_RBINTEGRITY() throws Exception {
+        System.out.println("testCrashAfterXA_RBINTEGRITY");
+
+        LocalServer originalServer = getLocalServer("1000");
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(originalServer.getClassLoader());
+        TransactionManager transactionManager = originalServer.getTransactionManager();
+        transactionManager.begin();
+        Transaction originalTransaction = transactionManager.getTransaction();
+        String get_uid = originalServer.get_uid();
+        originalTransaction.enlistResource(new TestResource(originalServer.getNodeName(), false));
+        TestResource testResource = new TestResource(originalServer.getNodeName(), false, true, new XAException(XAException.XA_RBINTEGRITY));
+        originalTransaction.enlistResource(testResource);
+        try {
+            transactionManager.commit();
+            fail("The transaction should not be able to commit normally");
+        } catch (HeuristicMixedException hme) {
+            // One of the resources did rollback
+        }
+        Thread.currentThread().setContextClassLoader(classLoader);
+
+        // Make sure that upon recovery an xa directive is not issued
+        assertTrue("" + completionCounter.getCommitCount("1000"), completionCounter.getCommitCount("1000") == 2);
+        assertTrue("" + completionCounter.getRollbackCount("1000"), completionCounter.getRollbackCount("1000") == 0);
+        getLocalServer("1000").doRecoveryManagerScan(true);
+        assertTrue("" + completionCounter.getCommitCount("1000"), completionCounter.getCommitCount("1000") == 2);
+        assertTrue("" + completionCounter.getRollbackCount("1000"), completionCounter.getRollbackCount("1000") == 0);
+
+        // Make sure that the Xid of the testResource is expectedly listed as a heuristic
+        String outcome = getLocalServer("1000").checkHeuristic(get_uid);
+        assertTrue(outcome.contains(testResource.getFatalXid().toString()));
+
+        // Make sure that upon recovery an xa directive is issued
+        getLocalServer("1000").doRecoveryManagerScan(true);
+        assertTrue("" + completionCounter.getCommitCount("1000"), completionCounter.getCommitCount("1000") == 3);
+        assertTrue("" + completionCounter.getRollbackCount("1000"), completionCounter.getRollbackCount("1000") == 0);
     }
 
     private void reboot(String serverName) throws Exception {

--- a/ArjunaJTS/integration/src/test/java/com/arjuna/ats/jta/distributed/server/CompletionCounter.java
+++ b/ArjunaJTS/integration/src/test/java/com/arjuna/ats/jta/distributed/server/CompletionCounter.java
@@ -5,11 +5,12 @@
 
 package com.arjuna.ats.jta.distributed.server;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-public class CompletionCounter {
+public class CompletionCounter implements Serializable {
 
 	private static CompletionCounter instance;
 

--- a/ArjunaJTS/integration/src/test/java/com/arjuna/ats/jta/distributed/server/LocalServer.java
+++ b/ArjunaJTS/integration/src/test/java/com/arjuna/ats/jta/distributed/server/LocalServer.java
@@ -30,6 +30,8 @@ public interface LocalServer {
 
 	public TransactionManager getTransactionManager() throws NotSupportedException, SystemException;
 
+	public String get_uid() throws SystemException;
+
 	public void doRecoveryManagerScan(boolean shortenSafetyInterval);
 
 	public long getTimeLeftBeforeTransactionTimeout() throws RollbackException;
@@ -48,4 +50,6 @@ public interface LocalServer {
 	public void shutdown() throws Exception;
 
     public XAResource generateProxyXAResource(String nextServerNodeName, Xid proxyRequired, boolean handleError) throws SystemException, IOException;
+
+	String checkHeuristic(String getUid);
 }

--- a/ArjunaJTS/integration/src/test/java/com/arjuna/ats/jta/distributed/server/impl/ProxyXAResourceDeserializer.java
+++ b/ArjunaJTS/integration/src/test/java/com/arjuna/ats/jta/distributed/server/impl/ProxyXAResourceDeserializer.java
@@ -9,13 +9,14 @@ import java.io.ObjectInputStream;
 
 import javax.transaction.xa.XAResource;
 
+import com.arjuna.ats.jta.distributed.TestResource;
 import com.arjuna.ats.jta.recovery.SerializableXAResourceDeserializer;
 
 public class ProxyXAResourceDeserializer implements SerializableXAResourceDeserializer {
 
 	@Override
 	public boolean canDeserialze(String className) {
-		if (className.equals(ProxyXAResource.class.getName())) {
+		if (className.equals(ProxyXAResource.class.getName()) || className.equals(TestResource.class.getName())) {
 			return true;
 		} else {
 			return false;

--- a/ArjunaJTS/integration/src/test/java/com/arjuna/ats/jta/distributed/server/impl/ServerImpl.java
+++ b/ArjunaJTS/integration/src/test/java/com/arjuna/ats/jta/distributed/server/impl/ServerImpl.java
@@ -11,6 +11,7 @@ import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.arjuna.ats.arjuna.common.Uid;
 import jakarta.transaction.RollbackException;
 import jakarta.transaction.Synchronization;
 import jakarta.transaction.SystemException;
@@ -29,6 +30,7 @@ import com.arjuna.ats.arjuna.common.CoreEnvironmentBean;
 import com.arjuna.ats.arjuna.common.CoreEnvironmentBeanException;
 import com.arjuna.ats.arjuna.common.ObjectStoreEnvironmentBean;
 import com.arjuna.ats.arjuna.common.RecoveryEnvironmentBean;
+import com.arjuna.ats.internal.arjuna.tools.log.EditableAtomicAction;
 import com.arjuna.ats.arjuna.coordinator.TransactionReaper;
 import com.arjuna.ats.arjuna.coordinator.TxControl;
 import com.arjuna.ats.arjuna.recovery.RecoveryManager;
@@ -205,6 +207,10 @@ public class ServerImpl implements LocalServer {
 		return transactionManagerService.getTransactionManager();
 	}
 
+	public String get_uid () throws SystemException {
+		return ((TransactionImple) transactionManagerService.getTransactionManager().getTransaction()).get_uid().stringForm();
+	}
+
 	@Override
 	public Xid locateOrImportTransactionThenResumeIt(int remainingTimeout, Xid toResume) throws XAException, IllegalStateException, SystemException,
 			IOException {
@@ -256,6 +262,19 @@ public class ServerImpl implements LocalServer {
     public ProxyXAResource generateProxyXAResource(String remoteServerName, Xid migratedXid, boolean handleError) throws SystemException, IOException {
         return new ProxyXAResource(nodeName, remoteServerName, migratedXid, handleError);
     }
+
+	@Override
+	public String checkHeuristic(String getUid) {
+		ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+		Thread.currentThread().setContextClassLoader(getClassLoader());
+
+		EditableAtomicAction editableAtomicAction = new EditableAtomicAction(new Uid(getUid));
+		String toReturn = editableAtomicAction.toString();
+		// Doesn't generate an error, just can log something
+		editableAtomicAction.moveHeuristicToPrepared(0);
+		Thread.currentThread().setContextClassLoader(classLoader);
+		return toReturn;
+	}
 
 	@Override
 	public Synchronization generateProxySynchronization(String remoteServerName, Xid toRegisterAgainst) {


### PR DESCRIPTION
@jmfinelli please look at this test. I am thinking that _rolledBack being saved only helps a narrow set of use case because I don't think unless  the XAResource is serializable, it will not have an effect after the record is loaded from disk.

Without the commit that changes resource to serializable, then in the debugger I can see _rolledBack being handled in restore_state but because the XAResourceRecord does not have a reference to the XAResource we can't manage to actually do a moveHeuristicToPrepared and try the recovery again (which is when the _rolledBack would be used).

This should help to test https://github.com/jbosstm/narayana/pull/2214